### PR TITLE
[-] Fix links in the configuration page

### DIFF
--- a/views/templates/hook/list.tpl
+++ b/views/templates/hook/list.tpl
@@ -24,7 +24,7 @@
 *}
 <div class="panel"><h3><i class="icon-list-ul"></i> {l s='Slides list' mod='ps_imageslider'}
 	<span class="panel-heading-action">
-		<a id="desc-product-new" class="list-toolbar-btn" href="{$link->getAdminLink('AdminModules')}&configure=homeslider&addSlide=1">
+		<a id="desc-product-new" class="list-toolbar-btn" href="{$link->getAdminLink('AdminModules')}&configure=ps_imageslider&addSlide=1">
 			<span title="" data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='Add new' mod='ps_imageslider'}" data-html="true">
 				<i class="process-icon-new "></i>
 			</span>
@@ -57,12 +57,12 @@
 								{$slide.status}
 
 								<a class="btn btn-default"
-									href="{$link->getAdminLink('AdminModules')}&configure=homeslider&id_slide={$slide.id_slide}">
+									href="{$link->getAdminLink('AdminModules')}&configure=ps_imageslider&id_slide={$slide.id_slide}">
 									<i class="icon-edit"></i>
 									{l s='Edit' mod='ps_imageslider'}
 								</a>
 								<a class="btn btn-default"
-									href="{$link->getAdminLink('AdminModules')}&configure=homeslider&delete_id_slide={$slide.id_slide}">
+									href="{$link->getAdminLink('AdminModules')}&configure=ps_imageslider&delete_id_slide={$slide.id_slide}">
 									<i class="icon-trash"></i>
 									{l s='Delete' mod='ps_imageslider'}
 								</a>


### PR DESCRIPTION
This PR fixes the links in the configuration page of ps_homeslider.

Currently, we still have the old module name in the templates, which bring the following error:
```
You need to be logged in to your PrestaShop Addons account in order to update the homeslider module. Click here to log in.
```