### PR TITLE
Fixed selector in homeslider.js

### DIFF
--- a/js/homeslider.js
+++ b/js/homeslider.js
@@ -27,10 +27,10 @@
 jQuery(document).ready(function ($) {
   var homesliderConfig = {
     speed: 500,            // Integer: Speed of the transition, in milliseconds
-    timeout: $('.homeslider').data('interval'),          // Integer: Time between slide transitions, in milliseconds
+    timeout: $('.homeslider-container').data('interval'), // Integer: Time between slide transitions, in milliseconds
     nav: true,             // Boolean: Show navigation, true or false
     random: false,          // Boolean: Randomize the order of the slides, true or false
-    pause: $('.homeslider').data('pause'),           // Boolean: Pause on hover, true or false
+    pause: $('.homeslider-container').data('pause'), // Boolean: Pause on hover, true or false
     maxwidth: "",           // Integer: Max-width of the slideshow, in pixels
     namespace: "homeslider",   // String: Change the default namespace used
     before: function(){},   // Function: Before callback


### PR DESCRIPTION
There was a bug in homeslider.js where data was being retrieved from the view, which caused undefined timeout and pause parameters in config variable.

Data in the view is located on the .homeslider-container element, but the selector was pointing to .homeslider element.