### PR TITLE
[mobile_slides] Showing different slides in mobile version.

### DIFF
--- a/Ps_HomeSlide.php
+++ b/Ps_HomeSlide.php
@@ -33,6 +33,7 @@ class Ps_HomeSlide extends ObjectModel
 	public $image;
 	public $active;
 	public $position;
+	public $mobile;
 	public $id_shop;
 
 	/**
@@ -45,6 +46,7 @@ class Ps_HomeSlide extends ObjectModel
 		'fields' => array(
 			'active' =>			array('type' => self::TYPE_BOOL, 'validate' => 'isBool', 'required' => true),
 			'position' =>		array('type' => self::TYPE_INT, 'validate' => 'isunsignedInt', 'required' => true),
+			'mobile' =>			array('type' => self::TYPE_INT, 'validate' => 'isunsignedInt', 'required' => true),
 
 			// Lang fields
 			'description' =>	array('type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => 4000),

--- a/css/homeslider.css
+++ b/css/homeslider.css
@@ -72,3 +72,22 @@
   background-position: right top;
   right: 0;
 }
+
+/* Show or hide mobile slider */
+@media (max-width: 767px) {
+  .homeslider-container-no-mobile {
+    display: none;
+  }
+	.homeslider-container-mobile {
+    display: block;
+  }
+}
+
+@media (min-width: 767px) {
+	.homeslider-container-no-mobile {
+    display: block;
+  }
+	.homeslider-container-mobile {
+    display: none;
+  }
+}

--- a/js/homeslider.js
+++ b/js/homeslider.js
@@ -39,4 +39,21 @@ jQuery(document).ready(function ($) {
 
   $(".rslides").responsiveSlides(homesliderConfig);
 
+  var homesliderConfigMobile = {
+    speed: 500,            // Integer: Speed of the transition, in milliseconds
+    timeout: $('.homeslider-container').data('interval'), // Integer: Time between slide transitions, in milliseconds
+    nav: true,             // Boolean: Show navigation, true or false
+    random: false,          // Boolean: Randomize the order of the slides, true or false
+    pause: $('.homeslider-container').data('pause'), // Boolean: Pause on hover, true or false
+    maxwidth: "",           // Integer: Max-width of the slideshow, in pixels
+    namespace: "homeslider",   // String: Change the default namespace used
+    before: function(){},   // Function: Before callback
+    after: function(){}     // Function: After callback
+  };
+
+  var rSlidesMobile = $(".rslides-mobile");
+  if (rSlidesMobile) {
+    $(".rslides-mobile").responsiveSlides(homesliderConfigMobile);
+  }
+
 });

--- a/views/templates/hook/list.tpl
+++ b/views/templates/hook/list.tpl
@@ -55,6 +55,7 @@
 							</h4>
 							<div class="btn-group-action pull-right">
 								{$slide.status}
+								{$slide.mobile}
 
 								<a class="btn btn-default"
 									href="{$link->getAdminLink('AdminModules')}&configure=ps_imageslider&id_slide={$slide.id_slide}">

--- a/views/templates/hook/slider.tpl
+++ b/views/templates/hook/slider.tpl
@@ -25,9 +25,34 @@
 *}
 
 {if $homeslider.slides}
-  <div class="homeslider-container" data-interval="{$homeslider.speed}" data-wrap="{$homeslider.wrap}" data-pause="{$homeslider.pause}">
+  <div class="homeslider-container homeslider-container-no-mobile" data-interval="{$homeslider.speed}" data-wrap="{$homeslider.wrap}" data-pause="{$homeslider.pause}">
     <ul class="rslides">
       {foreach from=$homeslider.slides item=slide}
+        <li class="slide">
+          <a href="{$slide.url}">
+            <img src="{$slide.image_url}" alt="{$slide.legend|escape}" />
+            {if $slide.title || $slide.description }
+              <span class="caption">
+                <h2>{$slide.title}</h2>
+                <div>{$slide.description nofilter}</div>
+              </span>
+            {/if}
+          </a>
+        </li>
+      {/foreach}
+    </ul>
+  </div>
+{/if}
+
+{assign var=slides_mobile value=$homeslider.slides_mobile}
+{if !$homeslider.slides_mobile}
+  {assign var=slides_mobile value=$homeslider.slides}
+{/if}
+
+{if $slides_mobile}
+  <div class="homeslider-container homeslider-container-mobile" data-interval="{$homeslider.speed}" data-wrap="{$homeslider.wrap}" data-pause="{$homeslider.pause}">
+    <ul class="rslides-mobile">
+      {foreach from=$slides_mobile item=slide}
         <li class="slide">
           <a href="{$slide.url}">
             <img src="{$slide.image_url}" alt="{$slide.legend|escape}" />


### PR DESCRIPTION
In mobile version horizontal banners are shown very small. For this reason I have added the possibility of define specific slides for mobile version. 

To do it I have added a property to the slide as "mobile". If there are not mobile slides, the rest of slides are shown, but if one mobile slide is found, then that slide is shown when mobile version of website is running. 

I didn't prepare it to be updated because I don't know how it works, it is the first time I modify a module. If you consider this feature is right and you will accept the pull request I can investigate and develop it.

I have it already working in [https://www.esenciacustome.com](https://www.esenciacustome.com) with default theme that I had to change the template too, but I can do another pull request to make it compatible if this is accepted.

Commit message: 

BO: Each slide has a new check for mobile version. If it is checked the mobile slider will show only these slides and they won't be shown in desktop or tablet version.
FO: Now there are two slides in the template. Only one is shown at same time. If there are not mobile slides, then all slides are shown in both types.
NOTE: To update it is necessary to add the field 'mobile' to the table ''PREFIX_homeslider_slides' of the database. Or uninstall and install again.