### PR TITLE
to have just one value, we should use getValue()

### DIFF
--- a/Ps_HomeSlide.php
+++ b/Ps_HomeSlide.php
@@ -102,7 +102,7 @@ class Ps_HomeSlide extends ObjectModel
 		$context = Context::getContext();
 		$id_shop = $context->shop->id;
 
-		$max = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+		$max = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
 			SELECT MAX(hss.`position`) as position
 			FROM `'._DB_PREFIX_.'homeslider_slides` hss, `'._DB_PREFIX_.'homeslider` hs
 			WHERE hss.`id_homeslider_slides` = hs.`id_homeslider_slides` AND hs.`id_shop` = '.(int)$id_shop
@@ -120,8 +120,8 @@ class Ps_HomeSlide extends ObjectModel
 
 		foreach ($rows as $row)
 		{
-			$current_slide = new Ps_HomeSlide($row['id_slide']);
-			--$current_slide->position;
+			$current_slide = new Ps_HomeSlide((int)$row['id_slide']);
+			$current_slide->position--;
 			$current_slide->update();
 			unset($current_slide);
 		}


### PR DESCRIPTION
to have just one value, we should use getValue()
(int)$row['id_slide'] : just transform the id from string to int
$current_slide->position-- : in this cas is the same $current_slide->position--;

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
