### PR TITLE
Use of getValue() instead of getRow()

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -624,13 +624,11 @@ class Ps_ImageSlider extends Module implements WidgetInterface
 
     public function getNextPosition()
     {
-        $row = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
-            SELECT MAX(hss.`position`) AS `next_position`
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('
+            SELECT MAX(hss.`position`) + 1 AS `next_position`
             FROM `'._DB_PREFIX_.'homeslider_slides` hss, `'._DB_PREFIX_.'homeslider` hs
             WHERE hss.`id_homeslider_slides` = hs.`id_homeslider_slides` AND hs.`id_shop` = '.(int)$this->context->shop->id
         );
-
-        return (++$row['next_position']);
     }
 
     public function getSlides($active = null)


### PR DESCRIPTION
Use of getValue() instead of getRow() to guarantee one value in the result

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
