### PR TITLE
Fix position to the top for hook displayHome

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -80,7 +80,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
             $this->registerHook('displayHome') &&
             $this->registerHook('actionShopDataDuplication')
         ) {
-            //Fix slider position to the top
+            // Set slider position to the top
             $this->updatePosition(Hook::getIdByName('displayHome'), false, 1);
             
             $shops = Shop::getContextListShopID();

--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -80,6 +80,9 @@ class Ps_ImageSlider extends Module implements WidgetInterface
             $this->registerHook('displayHome') &&
             $this->registerHook('actionShopDataDuplication')
         ) {
+            //Fix slider position to the top
+            $this->updatePosition(Hook::getIdByName('displayHome'), false, 1);
+            
             $shops = Shop::getContextListShopID();
             $shop_groups_list = array();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | on reset or uninstall then install, modules are hooked in the wrong place
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | Fixes PrestaShop/Prestashop#20748
| How to test?  | Steps to Reproduce<br>Steps to reproduce the behavior:<br><br>Go to BO > Module Manager page > Search for the slider module<br>Click on reset<br>Go to FO > Home page<br>See error => the slider is at the last position on the home page

