### PR TITLE
Allow internal anchors

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -575,7 +575,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
 
     protected function updateUrl($link)
     {
-        if (substr($link, 0, 7) !== 'http://' && substr($link, 0, 8) !== 'https://') {
+        if (substr($link, 0, 7) !== 'http://' && substr($link, 0, 8) !== 'https://' && substr($link, 0, 1) !== "#") {
             $link = 'http://' . $link;
         }
 

--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -575,7 +575,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
 
     protected function updateUrl($link)
     {
-        if (substr($link, 0, 7) !== 'http://' && substr($link, 0, 8) !== 'https://' && substr($link, 0, 1) !== "#") {
+        if (substr($link, 0, 7) !== 'http://' && substr($link, 0, 8) !== 'https://' && substr($link, 0, 1) !== '#') {
             $link = 'http://' . $link;
         }
 


### PR DESCRIPTION
Add condition to "updateUrl" method

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Allow internal anchors, so not add `http://` before a URL that starts with `#`
| Type?         |  improvement
| BC breaks?    | no
| Deprecations? | no
| How to test?  |- Create or edit a slide<br>- Insert internal anchor in the URL filed (i.e. "#internal-anchor")<br>- Save the slide<br>- Create a `div` element or any other HTML element and add the id property (i.e. `id="internal-anchor"` in the footer)<br>- Click on the slide, should point to a section of the page with that id, not to `about:blank#blocked`.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
