### PR TITLE
shorten trans call

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -65,8 +65,8 @@ class Ps_ImageSlider extends Module implements WidgetInterface
 
         parent::__construct();
 
-        $this->displayName = $this->getTranslator()->trans('Image slider', [], 'Modules.Imageslider.Admin');
-        $this->description = $this->getTranslator()->trans('Add sliding images to your homepage to welcome your visitors in a visual and friendly way.', [], 'Modules.Imageslider.Admin');
+        $this->displayName = $this->trans('Image slider', [], 'Modules.Imageslider.Admin');
+        $this->description = $this->trans('Add sliding images to your homepage to welcome your visitors in a visual and friendly way.', [], 'Modules.Imageslider.Admin');
         $this->ps_versions_compliancy = ['min' => '1.7.4.0', 'max' => _PS_VERSION_];
 
         $this->templateFile = 'module:ps_imageslider/views/templates/hook/slider.tpl';
@@ -304,59 +304,59 @@ class Ps_ImageSlider extends Module implements WidgetInterface
         /* Validation for Slider configuration */
         if (Tools::isSubmit('submitSlider')) {
             if (!Validate::isInt(Tools::getValue('HOMESLIDER_SPEED'))) {
-                $errors[] = $this->getTranslator()->trans('Invalid values', [], 'Modules.Imageslider.Admin');
+                $errors[] = $this->trans('Invalid values', [], 'Modules.Imageslider.Admin');
             }
         } elseif (Tools::isSubmit('changeStatus')) {
             if (!Validate::isInt(Tools::getValue('id_slide'))) {
-                $errors[] = $this->getTranslator()->trans('Invalid slide', [], 'Modules.Imageslider.Admin');
+                $errors[] = $this->trans('Invalid slide', [], 'Modules.Imageslider.Admin');
             }
         } elseif (Tools::isSubmit('submitSlide')) {
             /* Checks state (active) */
             if (!Validate::isInt(Tools::getValue('active_slide')) || (Tools::getValue('active_slide') != 0 && Tools::getValue('active_slide') != 1)) {
-                $errors[] = $this->getTranslator()->trans('Invalid slide state.', [], 'Modules.Imageslider.Admin');
+                $errors[] = $this->trans('Invalid slide state.', [], 'Modules.Imageslider.Admin');
             }
             /* If edit : checks id_slide */
             if (Tools::isSubmit('id_slide')) {
                 if (!Validate::isInt(Tools::getValue('id_slide')) && !$this->slideExists(Tools::getValue('id_slide'))) {
-                    $errors[] = $this->getTranslator()->trans('Invalid slide ID', [], 'Modules.Imageslider.Admin');
+                    $errors[] = $this->trans('Invalid slide ID', [], 'Modules.Imageslider.Admin');
                 }
             }
             /* Checks title/url/legend/description/image */
             $languages = Language::getLanguages(false);
             foreach ($languages as $language) {
                 if (Tools::strlen(Tools::getValue('title_' . $language['id_lang'])) > 255) {
-                    $errors[] = $this->getTranslator()->trans('The title is too long.', [], 'Modules.Imageslider.Admin');
+                    $errors[] = $this->trans('The title is too long.', [], 'Modules.Imageslider.Admin');
                 }
                 if (Tools::strlen(Tools::getValue('legend_' . $language['id_lang'])) > 255) {
-                    $errors[] = $this->getTranslator()->trans('The caption is too long.', [], 'Modules.Imageslider.Admin');
+                    $errors[] = $this->trans('The caption is too long.', [], 'Modules.Imageslider.Admin');
                 }
                 if (Tools::strlen(Tools::getValue('url_' . $language['id_lang'])) > 255) {
-                    $errors[] = $this->getTranslator()->trans('The URL is too long.', [], 'Modules.Imageslider.Admin');
+                    $errors[] = $this->trans('The URL is too long.', [], 'Modules.Imageslider.Admin');
                 }
                 if (Tools::strlen(Tools::getValue('description_' . $language['id_lang'])) > 4000) {
-                    $errors[] = $this->getTranslator()->trans('The description is too long.', [], 'Modules.Imageslider.Admin');
+                    $errors[] = $this->trans('The description is too long.', [], 'Modules.Imageslider.Admin');
                 }
                 if (Tools::strlen(Tools::getValue('url_' . $language['id_lang'])) > 0 && !Validate::isUrl(Tools::getValue('url_' . $language['id_lang']))) {
-                    $errors[] = $this->getTranslator()->trans('The URL format is not correct.', [], 'Modules.Imageslider.Admin');
+                    $errors[] = $this->trans('The URL format is not correct.', [], 'Modules.Imageslider.Admin');
                 }
                 if (Tools::getValue('image_' . $language['id_lang']) != null && !Validate::isFileName(Tools::getValue('image_' . $language['id_lang']))) {
-                    $errors[] = $this->getTranslator()->trans('Invalid filename.', [], 'Modules.Imageslider.Admin');
+                    $errors[] = $this->trans('Invalid filename.', [], 'Modules.Imageslider.Admin');
                 }
                 if (Tools::getValue('image_old_' . $language['id_lang']) != null && !Validate::isFileName(Tools::getValue('image_old_' . $language['id_lang']))) {
-                    $errors[] = $this->getTranslator()->trans('Invalid filename.', [], 'Modules.Imageslider.Admin');
+                    $errors[] = $this->trans('Invalid filename.', [], 'Modules.Imageslider.Admin');
                 }
             }
 
             /* Checks title/legend/description for default lang */
             $id_lang_default = (int) Configuration::get('PS_LANG_DEFAULT');
             if (!Tools::isSubmit('has_picture') && (!isset($_FILES['image_' . $id_lang_default]) || empty($_FILES['image_' . $id_lang_default]['tmp_name']))) {
-                $errors[] = $this->getTranslator()->trans('The image is not set.', [], 'Modules.Imageslider.Admin');
+                $errors[] = $this->trans('The image is not set.', [], 'Modules.Imageslider.Admin');
             }
             if (Tools::getValue('image_old_' . $id_lang_default) && !Validate::isFileName(Tools::getValue('image_old_' . $id_lang_default))) {
-                $errors[] = $this->getTranslator()->trans('The image is not set.', [], 'Modules.Imageslider.Admin');
+                $errors[] = $this->trans('The image is not set.', [], 'Modules.Imageslider.Admin');
             }
         } elseif (Tools::isSubmit('delete_id_slide') && (!Validate::isInt(Tools::getValue('delete_id_slide')) || !$this->slideExists((int) Tools::getValue('delete_id_slide')))) {
-            $errors[] = $this->getTranslator()->trans('Invalid slide ID', [], 'Modules.Imageslider.Admin');
+            $errors[] = $this->trans('Invalid slide ID', [], 'Modules.Imageslider.Admin');
         }
 
         /* Display errors if needed */
@@ -422,7 +422,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
             $this->clearCache();
 
             if (!$res) {
-                $errors[] = $this->displayError($this->getTranslator()->trans('The configuration could not be updated.', [], 'Modules.Imageslider.Admin'));
+                $errors[] = $this->displayError($this->trans('The configuration could not be updated.', [], 'Modules.Imageslider.Admin'));
             } else {
                 Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', true) . '&conf=6&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name);
             }
@@ -435,13 +435,13 @@ class Ps_ImageSlider extends Module implements WidgetInterface
             }
             $res = $slide->update();
             $this->clearCache();
-            $this->_html .= ($res ? $this->displayConfirmation($this->getTranslator()->trans('Configuration updated', [], 'Admin.Notifications.Success')) : $this->displayError($this->getTranslator()->trans('The configuration could not be updated.', [], 'Modules.Imageslider.Admin')));
+            $this->_html .= ($res ? $this->displayConfirmation($this->trans('Configuration updated', [], 'Admin.Notifications.Success')) : $this->displayError($this->getTranslator()->trans('The configuration could not be updated.', [], 'Modules.Imageslider.Admin')));
         } elseif (Tools::isSubmit('submitSlide')) {
             /* Sets ID if needed */
             if (Tools::getValue('id_slide')) {
                 $slide = new Ps_HomeSlide((int) Tools::getValue('id_slide'));
                 if (!Validate::isLoadedObject($slide)) {
-                    $this->_html .= $this->displayError($this->getTranslator()->trans('Invalid slide ID', [], 'Modules.Imageslider.Admin'));
+                    $this->_html .= $this->displayError($this->trans('Invalid slide ID', [], 'Modules.Imageslider.Admin'));
 
                     return false;
                 }
@@ -492,7 +492,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                     } elseif (!$temp_name || !move_uploaded_file($_FILES['image_' . $language['id_lang']]['tmp_name'], $temp_name)) {
                         return false;
                     } elseif (!ImageManager::resize($temp_name, __DIR__ . '/images/' . $salt . '_' . $_FILES['image_' . $language['id_lang']]['name'], null, null, $type)) {
-                        $errors[] = $this->displayError($this->getTranslator()->trans('An error occurred during the image upload process.', [], 'Admin.Notifications.Error'));
+                        $errors[] = $this->displayError($this->trans('An error occurred during the image upload process.', [], 'Admin.Notifications.Error'));
                     }
                     if (file_exists($temp_name)) {
                         @unlink($temp_name);
@@ -508,10 +508,10 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                 /* Adds */
                 if (!Tools::getValue('id_slide')) {
                     if (!$slide->add()) {
-                        $errors[] = $this->displayError($this->getTranslator()->trans('The slide could not be added.', [], 'Modules.Imageslider.Admin'));
+                        $errors[] = $this->displayError($this->trans('The slide could not be added.', [], 'Modules.Imageslider.Admin'));
                     }
                 } elseif (!$slide->update()) {
-                    $errors[] = $this->displayError($this->getTranslator()->trans('The slide could not be updated.', [], 'Modules.Imageslider.Admin'));
+                    $errors[] = $this->displayError($this->trans('The slide could not be updated.', [], 'Modules.Imageslider.Admin'));
                 }
                 $this->clearCache();
             }
@@ -702,7 +702,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
 
     public function displayStatus($id_slide, $active)
     {
-        $title = ((int) $active == 0 ? $this->getTranslator()->trans('Disabled', [], 'Admin.Global') : $this->getTranslator()->trans('Enabled', [], 'Admin.Global'));
+        $title = ((int) $active == 0 ? $this->trans('Disabled', [], 'Admin.Global') : $this->trans('Enabled', [], 'Admin.Global'));
         $icon = ((int) $active == 0 ? 'icon-remove' : 'icon-check');
         $class = ((int) $active == 0 ? 'btn-danger' : 'btn-success');
         $html = '<a class="btn ' . $class . '" href="' . AdminController::$currentIndex .
@@ -752,64 +752,64 @@ class Ps_ImageSlider extends Module implements WidgetInterface
         $fields_form = [
             'form' => [
                 'legend' => [
-                    'title' => $this->getTranslator()->trans('Slide information', [], 'Modules.Imageslider.Admin'),
+                    'title' => $this->trans('Slide information', [], 'Modules.Imageslider.Admin'),
                     'icon' => 'icon-cogs',
                 ],
                 'input' => [
                     [
                         'type' => 'file_lang',
-                        'label' => $this->getTranslator()->trans('Image', [], 'Admin.Global'),
+                        'label' => $this->trans('Image', [], 'Admin.Global'),
                         'name' => 'image',
                         'required' => true,
                         'lang' => true,
-                        'desc' => $this->getTranslator()->trans('Maximum image size: %s.', [ini_get('upload_max_filesize')], 'Admin.Global'),
+                        'desc' => $this->trans('Maximum image size: %s.', [ini_get('upload_max_filesize')], 'Admin.Global'),
                     ],
                     [
                         'type' => 'text',
-                        'label' => $this->getTranslator()->trans('Title', [], 'Admin.Global'),
+                        'label' => $this->trans('Title', [], 'Admin.Global'),
                         'name' => 'title',
                         'lang' => true,
                     ],
                     [
                         'type' => 'text',
-                        'label' => $this->getTranslator()->trans('Target URL', [], 'Modules.Imageslider.Admin'),
+                        'label' => $this->trans('Target URL', [], 'Modules.Imageslider.Admin'),
                         'name' => 'url',
                         'lang' => true,
                     ],
                     [
                         'type' => 'text',
-                        'label' => $this->getTranslator()->trans('Caption', [], 'Modules.Imageslider.Admin'),
+                        'label' => $this->trans('Caption', [], 'Modules.Imageslider.Admin'),
                         'name' => 'legend',
                         'lang' => true,
                     ],
                     [
                         'type' => 'textarea',
-                        'label' => $this->getTranslator()->trans('Description', [], 'Admin.Global'),
+                        'label' => $this->trans('Description', [], 'Admin.Global'),
                         'name' => 'description',
                         'autoload_rte' => true,
                         'lang' => true,
                     ],
                     [
                         'type' => 'switch',
-                        'label' => $this->getTranslator()->trans('Enabled', [], 'Admin.Global'),
+                        'label' => $this->trans('Enabled', [], 'Admin.Global'),
                         'name' => 'active_slide',
                         'is_bool' => true,
                         'values' => [
                             [
                                 'id' => 'active_on',
                                 'value' => 1,
-                                'label' => $this->getTranslator()->trans('Yes', [], 'Admin.Global'),
+                                'label' => $this->trans('Yes', [], 'Admin.Global'),
                             ],
                             [
                                 'id' => 'active_off',
                                 'value' => 0,
-                                'label' => $this->getTranslator()->trans('No', [], 'Admin.Global'),
+                                'label' => $this->trans('No', [], 'Admin.Global'),
                             ],
                         ],
                     ],
                 ],
                 'submit' => [
-                    'title' => $this->getTranslator()->trans('Save', [], 'Admin.Actions'),
+                    'title' => $this->trans('Save', [], 'Admin.Actions'),
                 ],
             ],
         ];
@@ -872,57 +872,57 @@ class Ps_ImageSlider extends Module implements WidgetInterface
         $fields_form = [
             'form' => [
                 'legend' => [
-                    'title' => $this->getTranslator()->trans('Settings', [], 'Admin.Global'),
+                    'title' => $this->trans('Settings', [], 'Admin.Global'),
                     'icon' => 'icon-cogs',
                 ],
                 'input' => [
                     [
                         'type' => 'text',
-                        'label' => $this->getTranslator()->trans('Speed', [], 'Modules.Imageslider.Admin'),
+                        'label' => $this->trans('Speed', [], 'Modules.Imageslider.Admin'),
                         'name' => 'HOMESLIDER_SPEED',
                         'suffix' => 'milliseconds',
                         'class' => 'fixed-width-sm',
-                        'desc' => $this->getTranslator()->trans('The duration of the transition between two slides.', [], 'Modules.Imageslider.Admin'),
+                        'desc' => $this->trans('The duration of the transition between two slides.', [], 'Modules.Imageslider.Admin'),
                     ],
                     [
                         'type' => 'switch',
-                        'label' => $this->getTranslator()->trans('Pause on hover', [], 'Modules.Imageslider.Admin'),
+                        'label' => $this->trans('Pause on hover', [], 'Modules.Imageslider.Admin'),
                         'name' => 'HOMESLIDER_PAUSE_ON_HOVER',
-                        'desc' => $this->getTranslator()->trans('Stop sliding when the mouse cursor is over the slideshow.', [], 'Modules.Imageslider.Admin'),
+                        'desc' => $this->trans('Stop sliding when the mouse cursor is over the slideshow.', [], 'Modules.Imageslider.Admin'),
                         'values' => [
                             [
                                 'id' => 'active_on',
                                 'value' => 1,
-                                'label' => $this->getTranslator()->trans('Yes', [], 'Admin.Global'),
+                                'label' => $this->trans('Yes', [], 'Admin.Global'),
                             ],
                             [
                                 'id' => 'active_off',
                                 'value' => 0,
-                                'label' => $this->getTranslator()->trans('No', [], 'Admin.Global'),
+                                'label' => $this->trans('No', [], 'Admin.Global'),
                             ],
                         ],
                     ],
                     [
                         'type' => 'switch',
-                        'label' => $this->getTranslator()->trans('Loop forever', [], 'Modules.Imageslider.Admin'),
+                        'label' => $this->trans('Loop forever', [], 'Modules.Imageslider.Admin'),
                         'name' => 'HOMESLIDER_WRAP',
-                        'desc' => $this->getTranslator()->trans('Loop or stop after the last slide.', [], 'Modules.Imageslider.Admin'),
+                        'desc' => $this->trans('Loop or stop after the last slide.', [], 'Modules.Imageslider.Admin'),
                         'values' => [
                             [
                                 'id' => 'active_on',
                                 'value' => 1,
-                                'label' => $this->getTranslator()->trans('Yes', [], 'Admin.Global'),
+                                'label' => $this->trans('Yes', [], 'Admin.Global'),
                             ],
                             [
                                 'id' => 'active_off',
                                 'value' => 0,
-                                'label' => $this->getTranslator()->trans('No', [], 'Admin.Global'),
+                                'label' => $this->trans('No', [], 'Admin.Global'),
                             ],
                         ],
                     ],
                 ],
                 'submit' => [
-                    'title' => $this->getTranslator()->trans('Save', [], 'Admin.Actions'),
+                    'title' => $this->trans('Save', [], 'Admin.Actions'),
                 ],
             ],
         ];
@@ -1000,7 +1000,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
     protected function getMultiLanguageInfoMsg()
     {
         return '<p class="alert alert-warning">' .
-                    $this->getTranslator()->trans('Since multiple languages are activated on your shop, please mind to upload your image for each one of them', [], 'Modules.Imageslider.Admin') .
+                    $this->trans('Since multiple languages are activated on your shop, please mind to upload your image for each one of them', [], 'Modules.Imageslider.Admin') .
                 '</p>';
     }
 
@@ -1008,7 +1008,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
     {
         if (Shop::getContext() == Shop::CONTEXT_GROUP || Shop::getContext() == Shop::CONTEXT_ALL) {
             return '<p class="alert alert-warning">' .
-            $this->getTranslator()->trans('You cannot manage slides items from a "All Shops" or a "Group Shop" context, select directly the shop you want to edit', [], 'Modules.Imageslider.Admin') .
+            $this->trans('You cannot manage slides items from a "All Shops" or a "Group Shop" context, select directly the shop you want to edit', [], 'Modules.Imageslider.Admin') .
             '</p>';
         } else {
             return '';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Module class has its own [trans](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/module/Module.php#L3363) function so we need to replace `getTranslator()->trans` by `trans` to keep consistency and briefness.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#30193
| How to test?  | Nothing changes in module's behaviour. Check the Module `trans` code in the above Description is the best way verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
