### PR TITLE
Fix for issue where sortable is trying to load when not needed

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -618,7 +618,9 @@ class Ps_ImageSlider extends Module implements WidgetInterface
 
     public function headerHTML()
     {
-        if (Tools::getValue('controller') != 'AdminModules' && Tools::getValue('configure') != $this->name) {
+        if ('AdminModules' !== Tools::getValue('controller') ||
+            Tools::getValue('configure') !== $this->name ||
+            Tools::getIsset('id_slide')) {
             return;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix for issue where sortable is trying to load when not needed.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#31980.
| How to test?  | Follow instructions in ticket.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
