### PR TITLE
 Update build-release.yml using Organization config 

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,59 +2,6 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-    deploy:
-        name: build dependencies & create artifact
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2.0.0
-            - name: Install composer dependencies
-              run: composer install --no-dev -o
-            - name: Clean-up project
-              uses: PrestaShopCorp/github-action-clean-before-deploy@v1.0
-            - name: Prepare auto-index tool
-              run: composer global require prestashop/autoindex
-            - name: Generate index.php
-              run: ~/.composer/vendor/bin/autoindex
-            - name: Create & upload artifact
-              uses: actions/upload-artifact@v1
-              with:
-                  name: ${{ github.event.repository.name }}
-                  path: ../
-    update_release_draft:
-        runs-on: ubuntu-latest
-        needs: [deploy]
-        if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
-        steps:
-            - name: Download artifact
-              uses: actions/download-artifact@v1
-              with:
-                  name: ${{ github.event.repository.name }}
-            - id: release_info
-              uses: toolmantim/release-drafter@v5
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Prepare for Release
-              run: |
-                  cd ${{ github.event.repository.name }}
-                  zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}
-            - name: Clean existing assets
-              shell: bash
-              run: |
-                  curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-                  assets=`bin/hub api -t repos/${{ github.repository }}/releases/${{ steps.release_info.outputs.id }}/assets | awk '/\].url/ { print $2 }'`
-                  for asset in $assets
-                  do
-                      bin/hub api -X DELETE $asset
-                  done
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Publish to GitHub Release
-              uses: actions/upload-release-asset@v1.0.1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  upload_url: ${{ steps.release_info.outputs.upload_url }}
-                  asset_path: ./${{ github.event.repository.name }}/${{ github.event.repository.name }}.zip
-                  asset_name: ${{ github.event.repository.name }}.zip
-                  asset_content_type: application/zip
+  build-and-release-draft:
+    name: Build & Release draft
+    uses: PrestaShop/.github/.github/workflows/build-release.yml@master


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Current build-release.yml is outdated, that caused warnings in recent PRs such as [Release 3.1.3](https://github.com/PrestaShop/ps_imageslider/actions/runs/5159449832). Using up-to-date Organization will solve it.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue URL here}, Fixes #{another issue URL here}
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Build complete without warning.
