### PR TITLE
feat: remove mobile desactivation

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -119,9 +119,6 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                 $this->installSamples();
             }
 
-            // Disable on mobiles and tablets
-            $this->disableDevice(Context::DEVICE_MOBILE);
-
             return (bool) $res;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I am wondering why this module is disabled by default on mobile device. So I propose to make this module always enable by default, because the merchant is able to disable it on his BO. Moreover, we cannot update this configuration when a theme is installed, that's why I think it's better if the module is enabled on mobile by default what do you think about it ?
| Type?             | improvement / suggestion
| BC breaks?        | no
| Deprecations?     | 
| Fixed ticket?     |
| Sponsor company   | @PrestaShopCorp
| How to test?      | You just need to install the module, put your browser in mobile mode, refresh the page and check if the module still shows in mobile.
