### PR TITLE
Fix: Adding new image slide in "Image slider" module (ps_imageslider) does not work

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -615,7 +615,8 @@ class Ps_ImageSlider extends Module implements WidgetInterface
     {
         if ('AdminModules' !== Tools::getValue('controller') ||
             Tools::getValue('configure') !== $this->name ||
-            Tools::getIsset('id_slide')) {
+            Tools::getIsset('id_slide') ||
+            Tools::getIsset('addSlide')) {
             return;
         }
 


### PR DESCRIPTION
It is also necessary to check the case of creating a new slide (addSlide)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When trying to add a new slide in the ps_imageslider module, file selection doesn't work.<br><br>This problem occurs up to version 1.7.6.9 of Prestashop, in subsequent versions it does not occur, however the javascript error which is the cause of the problem is still there.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#35713](https://github.com/PrestaShop/PrestaShop/issues/35713)
| Sponsor company   | Codencode
