### PR TITLE
Added Avif and WebP support for slider images

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -43,6 +43,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
     protected $default_pause_on_hover = 1;
     protected $default_wrap = 1;
     protected $templateFile;
+    const SUPPORTED_MIME_TYPES = ['jpg', 'gif', 'jpeg', 'png', 'avif', 'webp'];
     /**
      * @var string
      */
@@ -472,16 +473,9 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                     !empty($imagesize) &&
                     in_array(
                         Tools::strtolower(Tools::substr(strrchr($imagesize['mime'], '/'), 1)),
-                        [
-                            'jpg',
-                            'gif',
-                            'jpeg',
-                            'png',
-                            'avif',
-                            'webp',
-                        ]
+                        self::SUPPORTED_MIME_TYPES
                     ) &&
-                    in_array($type, ['jpg', 'gif', 'jpeg', 'png', 'avif', 'webp'])
+                    in_array($type, self::SUPPORTED_MIME_TYPES)
                 ) {
                     $temp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS');
                     $salt = sha1(microtime());

--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -477,9 +477,11 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                             'gif',
                             'jpeg',
                             'png',
+                            'avif',
+                            'webp',
                         ]
                     ) &&
-                    in_array($type, ['jpg', 'gif', 'jpeg', 'png'])
+                    in_array($type, ['jpg', 'gif', 'jpeg', 'png', 'avif', 'webp'])
                 ) {
                     $temp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS');
                     $salt = sha1(microtime());


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I have added 2 new supported image extensions. Avif and WebP.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to upload Avif or WebP image.

Hi, I have created this PR to add supports for Avif and WebP extensions in slider images.