### PR TITLE
New error handling for unsupported image types

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -488,7 +488,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                     } elseif (!$temp_name || !move_uploaded_file($_FILES['image_' . $language['id_lang']]['tmp_name'], $temp_name)) {
                         return false;
                     } elseif (!ImageManager::resize($temp_name, __DIR__ . '/images/' . $salt . '_' . $_FILES['image_' . $language['id_lang']]['name'], null, null, $type)) {
-                        $errors[] = $this->displayError($this->trans('An error occurred during the image upload process.', [], 'Admin.Notifications.Error'));
+                        $errors[] = $this->trans('An error occurred during the image upload process.', [], 'Admin.Notifications.Error');
                     }
                     if (file_exists($temp_name)) {
                         @unlink($temp_name);
@@ -497,7 +497,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                 } elseif (Tools::getValue('image_old_' . $language['id_lang']) != '') {
                     $slide->image[$language['id_lang']] = Tools::getValue('image_old_' . $language['id_lang']);
                 } else {
-                    $errors[] = $this->displayError($this->trans('Uploaded file is not supported, only jpg, gif, jpeg, png are allowed.', [], 'Admin.Notifications.Error'));
+                    $errors[] = $this->trans('Image format not recognized, allowed formats are: jpg, gif, jpeg, png.', [], 'Admin.Notifications.Error');
                 }
             }
 
@@ -506,10 +506,10 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                 /* Adds */
                 if (!Tools::getValue('id_slide')) {
                     if (!$slide->add()) {
-                        $errors[] = $this->displayError($this->trans('The slide could not be added.', [], 'Modules.Imageslider.Admin'));
+                        $errors[] = $this->trans('The slide could not be added.', [], 'Modules.Imageslider.Admin');
                     }
                 } elseif (!$slide->update()) {
-                    $errors[] = $this->displayError($this->trans('The slide could not be updated.', [], 'Modules.Imageslider.Admin'));
+                    $errors[] = $this->trans('The slide could not be updated.', [], 'Modules.Imageslider.Admin');
                 }
                 $this->clearCache();
             }

--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -496,6 +496,8 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                     $slide->image[$language['id_lang']] = $salt . '_' . $_FILES['image_' . $language['id_lang']]['name'];
                 } elseif (Tools::getValue('image_old_' . $language['id_lang']) != '') {
                     $slide->image[$language['id_lang']] = Tools::getValue('image_old_' . $language['id_lang']);
+                } else {
+                    $errors[] = $this->displayError($this->trans('Uploaded file is not supported, only jpg, gif, jpeg, png are allowed.', [], 'Admin.Notifications.Error'));
                 }
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I have added a new error for users who upload a file that is not supported in extensions and/or mimetype.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to upload a new file that is not supported.

If we try to upload a new file that is not a valid image, no errors are shown. Backoffice returns success message and image remain the same. With this little "else" check we can track if the uploaded file was included in supported extensions and/or mimetypes.
