### PR TITLE
Fix: add required image for all languages

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -338,6 +338,9 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                 if (Tools::getValue('image_old_' . $language['id_lang']) != null && !Validate::isFileName(Tools::getValue('image_old_' . $language['id_lang']))) {
                     $errors[] = $this->trans('Invalid filename.', [], 'Modules.Imageslider.Admin');
                 }
+                if (!Tools::isSubmit('has_picture') && (!isset($_FILES['image_' . $language['id_lang']]) || empty($_FILES['image_' . $language['id_lang']]['tmp_name']))) {
+                    $errors[] = $this->trans('The image is not set.', [], 'Modules.Imageslider.Admin');
+                }
             }
 
             /* Checks title/legend/description for default lang */


### PR DESCRIPTION
All languages should be checked for required image

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing this change. What did you change? Why?
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{[33527](https://github.com/PrestaShop/PrestaShop/issues/33527)}, Fixes #{[36671](https://github.com/PrestaShop/PrestaShop/issues/36671)}
| Sponsor company   | Webo.agency.
| How to test?      | Check if saving of slide without image isn't possible. If not then is fixes. If yes then need another fix
