### PR TITLE
Fix sorting of slides

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_imageslider</name>
     <displayName><![CDATA[Image slider]]></displayName>
-    <version><![CDATA[3.2.0]]></version>
+    <version><![CDATA[3.2.1]]></version>
     <description><![CDATA[Adds an image slider to your site.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -666,12 +666,11 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                 new Sortable(slideList[0], {
                 animation: 150,
                 onUpdate: function (event) {
-                    var sortableIdsAsTableString = this.toArray();
-                    var sortableIdsAsData = sortableIdsAsTableString.map((x) => x.slice(-1));
+                    var slideIdList = this.toArray();
                     var ajaxCallParameters = {
                     ajax: true,
                     action: "updateSlidesPosition",
-                    slides: sortableIdsAsData
+                    slides: slideIdList
                     };
                     $.ajax({
                     type: "POST",

--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -52,7 +52,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
     {
         $this->name = 'ps_imageslider';
         $this->tab = 'front_office_features';
-        $this->version = '3.2.0';
+        $this->version = '3.2.1';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
         $this->secure_key = Tools::hash($this->name);

--- a/views/templates/hook/list.tpl
+++ b/views/templates/hook/list.tpl
@@ -28,7 +28,7 @@
 	<div id="slidesContent">
 		<div id="slides" class="list-group">
 			{foreach from=$slides item=slide}
-				<div id="slides_{$slide.id_slide}" class="panel list-group-item" data-id="slides[]={$slide.id_slide}">
+				<div id="slides_{$slide.id_slide}" class="panel list-group-item" data-id="{$slide.id_slide}">
 					<div class="row">
 						<div class="col-lg-1">
 							<span><i class="icon-arrows "></i></span>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Sorting worked only for single digit IDs. :-))) It's now fixed.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/37027
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Create more than 10 slides and try to sort them.
