### PR TITLE
Fix file name generation for uploaded images

### DIFF
--- a/ps_imageslider.php
+++ b/ps_imageslider.php
@@ -514,7 +514,7 @@ class Ps_ImageSlider extends Module implements WidgetInterface
                 ) {
                     $temp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS');
                     $salt = sha1(microtime());
-                    $file_name = Tools::str2url($_FILES['image_' . $language['id_lang']]['name']) . $type;
+                    $file_name = Tools::str2url(pathinfo($_FILES['image_' . $language['id_lang']]['name'], PATHINFO_FILENAME)) . '.' . $type;
                     if ($error = ImageManager::validateUpload($_FILES['image_' . $language['id_lang']])) {
                         $errors[] = $error;
                     } elseif (!$temp_name || !move_uploaded_file($_FILES['image_' . $language['id_lang']]['tmp_name'], $temp_name)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In the latest version of the module, newly uploaded slides (for example, after upgrade) have wrong file names (double extension concatenated in the name and no dot to separate it - for example: 48fef018a667ee0b10f9d4da0c619f8186a00f5test_namejpgjpg). This PR fixes the file name generation.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #119 
| How to test?      | Upload new images and see that now the file names are correct
