### PR TITLE
fix(AdminController): ob_end_clean without content creates error

### DIFF
--- a/controllers/admin/AdminConfigureSlidesController.php
+++ b/controllers/admin/AdminConfigureSlidesController.php
@@ -24,8 +24,8 @@ class AdminConfigureSlidesController extends ModuleAdminController
         if (empty(Tools::getValue('action')) || Tools::getValue('action') != 'updateSlidesPosition' || empty(Tools::getValue('slides'))) {
             if (ob_get_contents()) {
 	            ob_end_clean();
-	        }
-			
+            }
+
             header('Content-Type: application/json');
             $this->ajaxRender(json_encode(['error' => true]));
             exit;
@@ -45,8 +45,8 @@ class AdminConfigureSlidesController extends ModuleAdminController
 
         if (ob_get_contents()) {
 			ob_end_clean();
-		}
-		
+        }
+
         header('Content-Type: application/json');
         $this->ajaxRender(json_encode(['success' => true]));
         exit;

--- a/controllers/admin/AdminConfigureSlidesController.php
+++ b/controllers/admin/AdminConfigureSlidesController.php
@@ -23,7 +23,7 @@ class AdminConfigureSlidesController extends ModuleAdminController
     {
         if (empty(Tools::getValue('action')) || Tools::getValue('action') != 'updateSlidesPosition' || empty(Tools::getValue('slides'))) {
             if (ob_get_contents()) {
-	            ob_end_clean();
+                ob_end_clean();
             }
 
             header('Content-Type: application/json');
@@ -44,7 +44,7 @@ class AdminConfigureSlidesController extends ModuleAdminController
         $this->module->clearCache();
 
         if (ob_get_contents()) {
-		    ob_end_clean();
+            ob_end_clean();
         }
 
         header('Content-Type: application/json');

--- a/controllers/admin/AdminConfigureSlidesController.php
+++ b/controllers/admin/AdminConfigureSlidesController.php
@@ -22,7 +22,7 @@ class AdminConfigureSlidesController extends ModuleAdminController
     public function ajaxProcessUpdateSlidesPosition()
     {
         if (empty(Tools::getValue('action')) || Tools::getValue('action') != 'updateSlidesPosition' || empty(Tools::getValue('slides'))) {
-			if (ob_get_contents()) {
+            if (ob_get_contents()) {
 	            ob_end_clean();
 	        }
 			

--- a/controllers/admin/AdminConfigureSlidesController.php
+++ b/controllers/admin/AdminConfigureSlidesController.php
@@ -44,7 +44,7 @@ class AdminConfigureSlidesController extends ModuleAdminController
         $this->module->clearCache();
 
         if (ob_get_contents()) {
-			ob_end_clean();
+		    ob_end_clean();
         }
 
         header('Content-Type: application/json');

--- a/controllers/admin/AdminConfigureSlidesController.php
+++ b/controllers/admin/AdminConfigureSlidesController.php
@@ -22,7 +22,10 @@ class AdminConfigureSlidesController extends ModuleAdminController
     public function ajaxProcessUpdateSlidesPosition()
     {
         if (empty(Tools::getValue('action')) || Tools::getValue('action') != 'updateSlidesPosition' || empty(Tools::getValue('slides'))) {
-            ob_end_clean();
+			if (ob_get_contents()) {
+	            ob_end_clean();
+	        }
+			
             header('Content-Type: application/json');
             $this->ajaxRender(json_encode(['error' => true]));
             exit;
@@ -40,7 +43,10 @@ class AdminConfigureSlidesController extends ModuleAdminController
         // Wipe module cache
         $this->module->clearCache();
 
-        ob_end_clean();
+        if (ob_get_contents()) {
+			ob_end_clean();
+		}
+		
         header('Content-Type: application/json');
         $this->ajaxRender(json_encode(['success' => true]));
         exit;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When debug mode is active, reordering slides provokes a symfony exception, as we call ob_end_clean when there is no buffer content to clean. Notice: ob_end_clean(): Failed to delete buffer. No buffer to delete
| Type?             | bug fix
| BC breaks?        |no
| Deprecations?     | no
| Fixed ticket?     | #125 
| Sponsor company   | Evolutive
| How to test?      | Activate debug mode. Go to the module configuration and change slides order. Check in the network tab of the browser that calls made to update positions are not returning errors.
